### PR TITLE
Fixing typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [Hammer.js documentation](http://hammerjs.github.io/getting-started/) for al
   import { press } from 'svelte-hammer'
 </script>
 <div
-  use:pinch
+  use:press
   on:press={() => /* Press */}
   on:pressup={() => /* Press Up */}
 >

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import pan from './pan';
 import pinch from './pinch';
 import press from './press';
 import rotate from './rotate';
-import tap from './rotate';
+import tap from './tap';
 
 export {
   Hammer,


### PR DESCRIPTION
- import `tap` from `./tap` and not `./rotate` in `index.ts`
- `use:press` and not `use:pinch` in the README